### PR TITLE
Switching to DFINE model for RTSPLoader

### DIFF
--- a/common/rtsploader/README.md
+++ b/common/rtsploader/README.md
@@ -37,7 +37,7 @@ source: 'rtsp://<user>:<pass>@<camera-ip>',
 ## Object Detection enabled
 First, download and export [D-FINE](https://github.com/Peterande/D-FINE/tree/master) object detection model. Alternatively, if you have your own D-FINE model (in OpenVINO format), provide the path to the model as argument in RTSPChunkLoader.
 ```
-bash download_model.sh  # Creates 'ov_dfine/dfine-l-coco.xml & .bin'
+bash download_model.sh  # Creates 'ov_dfine/dfine-s-coco.xml & .bin'
 ```
 
 ```
@@ -51,7 +51,7 @@ rtsp_loader = RTSPChunkLoader(
         "fps": 15, # The framerate you save the chunk at
         "overlap": 15, # Number of frames of overlap between consecutive chunks
         "obj_detect_enabled": True,
-        "dfine_path": 'ov_dfine/dfine-l-coco.xml', # Path to the D-FINE model
+        "dfine_path": 'ov_dfine/dfine-s-coco.xml', # Path to the D-FINE model
         "dfine_sample_rate": 5, # Every 5th frame is infernced upon
         "detection_threshold": 0.7 # Only capture objects with detection confidence greater than 0.7
 

--- a/common/rtsploader/README.md
+++ b/common/rtsploader/README.md
@@ -52,7 +52,9 @@ rtsp_loader = RTSPChunkLoader(
         "overlap": 15, # Number of frames of overlap between consecutive chunks
         "obj_detect_enabled": True,
         "dfine_path": 'ov_dfine/dfine-l-coco.xml', # Path to the D-FINE model
-        "dfine_sample_rate": 5 # Every Nth frame is infernced upon
+        "dfine_sample_rate": 5, # Every 5th frame is infernced upon
+        "detection_threshold": 0.7 # Only capture objects with detection confidence greater than 0.7
+
     },
     output_dir='cam_1',
 )
@@ -69,10 +71,9 @@ Sliding Window Chunk metadata:
 'start_time': '2025-06-02T18:29:00.315088',
 'end_time': '2025-06-02T18:29:05.412887',
 'source': 'rtsp://<user>:<pass>@<camera-ip>',
-'detected_objects': [{'frame': 0,
-			'objects': [
-			    {'label': 'person', 'bbox': [2219.25439453125, 647.7630615234375, 2593.083740234375, 1600.69482421875]},
-			    {'label': 'surfboard', 'bbox': [2779.221435546875, 416.277099609375, 3021.228271484375, 1071.7967529296875]},
-			    {'label': 'chair', 'bbox': [115.33447265625, 1249.074951171875, 444.9425354003906, 1729.0045166015625]},
-			    {'label': 'couch', 'bbox': [106.50575256347656, 1886.9461669921875, 1974.1636962890625, 2147.5087890625]}]}, ...]
+'detected_objects': [{'frame': 0, 'objects': [
+			{'label': 'person', 'bbox': [2219.25, 647.76, 2593.08, 1600.69]},
+			{'label': 'surfboard', 'bbox': [2779.22, 416.27, 3021.22, 1071.79]},
+			{'label': 'chair', 'bbox': [115.33, 1249.07, 444.94, 1729.00]},
+			{'label': 'couch', 'bbox': [106.50, 1886.94, 1974.16, 2147.50]}]}, ...]
 ```

--- a/common/rtsploader/README.md
+++ b/common/rtsploader/README.md
@@ -1,8 +1,8 @@
 ## RTSPChunkLoader
 `RTSPChunkLoader` class exposes a document loader for creating video chunks from RTSP streams.
-Optionally, you can enable a yolo object detection model to record detected objects in the frames to the chunk documents.
+Optionally, you can enable a D-FINE object detection model to record detected objects in the frames to the chunk documents.
 
-### Yolo disabled
+### Object Detection disabled
 ```
 from rtsploader_wrapper import RTSPChunkLoader
 
@@ -13,41 +13,7 @@ rtsp_loader = RTSPChunkLoader(
         "window_size": 85, # Number of frames per chunk
         "fps": 15, # The framerate you save the chunk at
         "overlap": 15, # Number of frames of overlap between consecutive chunks
-        "yolo_enabled": False,
-    },
-    output_dir='cam_1',
-)
-
-for doc in rtsp_loader.lazy_load():
-    print(f"Sliding Window Chunk metadata: {doc.metadata}")
-```
-
-results in
-```
-Sliding Window Chunk metadata: {'chunk_id': '5b58wefoih234h334j', 'chunk_path': 'cam_1/chunk_2025-06-02_18-29-00.avi', 'start_time': '2025-06-02T18:29:00.315088', 'end_time': '2025-06-02T18:29:05.412887', source: 'rtsp://<user>:<pass>@<camera-ip>', 'detected_objects': []}
-```
-
-
-## Yolo enabled
-First, download and export ultralyics YOLO object detection model. Alternatively, if you have your own YOLO model, provide the path to the model as argument in RTSPChunkLoader.
-```
-pip install ultralytics
-yolo export model=yolo11n.pt # creates 'yolo11n.pt'
-```
-
-```
-from rtsploader_wrapper import rtsploader_wrapper
-
-rtsp_loader = RTSPChunkLoader(
-    rtsp_url="rtsp://<user>:<pass>@<camera-ip>",
-    chunk_type="sliding_window", # Traditional sliding window with overlap
-    chunk_args={
-        "window_size": 85, # Number of frames per chunk
-        "fps": 15, # The framerate you save the chunk at
-        "overlap": 15, # Number of frames of overlap between consecutive chunks
-        "yolo_enabled": True,
-        "yolo_path": 'yolo11n.pt', # Path to the ultralytics YOLO model
-        "yolo_sample_rate": 5 # Every Nth frame is infernced upon
+        "obj_detect_enabled": False,
     },
     output_dir='cam_1',
 )
@@ -58,5 +24,55 @@ for doc in rtsp_loader.lazy_load():
 
 results in:
 ```
-Sliding Window Chunk metadata: {'chunk_id': '3d3h45tfwef34fnb7ug', 'chunk_path': 'cam_1/chunk_2025-06-02_18-29-00.avi', 'start_time': '2025-06-02T18:29:00.315088', 'end_time': '2025-06-02T18:29:05.412887', 'source': 'rtsp://<user>:<pass>@<camera-ip>', 'detected_objects': [{'frame 15', 'objects': ['person', 'chair']}, {'frame 20', objects: ['person', 'chair', 'surfboard']}...]}
+Sliding Window Chunk metadata:
+{'chunk_id': '5b58wefoih234h334j',
+'chunk_path': 'cam_1/chunk_2025-06-02_18-29-00.avi',
+'start_time': '2025-06-02T18:29:00.315088',
+'end_time': '2025-06-02T18:29:05.412887',
+source: 'rtsp://<user>:<pass>@<camera-ip>',
+'detected_objects': []}
+```
+
+
+## Object Detection enabled
+First, download and export [D-FINE](https://github.com/Peterande/D-FINE/tree/master) object detection model. Alternatively, if you have your own D-FINE model (in OpenVINO format), provide the path to the model as argument in RTSPChunkLoader.
+```
+bash download_model.sh  # Creates 'ov_dfine/dfine-l-coco.xml & .bin'
+```
+
+```
+from rtsploader_wrapper import RTSPChunkLoader
+
+rtsp_loader = RTSPChunkLoader(
+    rtsp_url="rtsp://<user>:<pass>@<camera-ip>",
+    chunk_type="sliding_window", # Traditional sliding window with overlap
+    chunk_args={
+        "window_size": 85, # Number of frames per chunk
+        "fps": 15, # The framerate you save the chunk at
+        "overlap": 15, # Number of frames of overlap between consecutive chunks
+        "obj_detect_enabled": True,
+        "dfine_path": 'ov_dfine/dfine-l-coco.xml', # Path to the D-FINE model
+        "dfine_sample_rate": 5 # Every Nth frame is infernced upon
+    },
+    output_dir='cam_1',
+)
+
+for doc in rtsp_loader.lazy_load():
+    print(f"Sliding Window Chunk metadata: {doc.metadata}")
+```
+
+results in:
+```
+Sliding Window Chunk metadata: 
+{'chunk_id': '3d3h45tfwef34fnb7ug',
+'chunk_path': 'cam_1/chunk_2025-06-02_18-29-00.avi',
+'start_time': '2025-06-02T18:29:00.315088',
+'end_time': '2025-06-02T18:29:05.412887',
+'source': 'rtsp://<user>:<pass>@<camera-ip>',
+'detected_objects': [{'frame': 0,
+			'objects': [
+			    {'label': 'person', 'bbox': [2219.25439453125, 647.7630615234375, 2593.083740234375, 1600.69482421875]},
+			    {'label': 'surfboard', 'bbox': [2779.221435546875, 416.277099609375, 3021.228271484375, 1071.7967529296875]},
+			    {'label': 'chair', 'bbox': [115.33447265625, 1249.074951171875, 444.9425354003906, 1729.0045166015625]},
+			    {'label': 'couch', 'bbox': [106.50575256347656, 1886.9461669921875, 1974.1636962890625, 2147.5087890625]}]}, ...]
 ```

--- a/common/rtsploader/dfine_ovinfer.py
+++ b/common/rtsploader/dfine_ovinfer.py
@@ -1,3 +1,9 @@
+"""
+Copyright (c) 2024 The D-FINE Authors. All Rights Reserved.
+ 
+Source file from DFINE: https://github.com/Peterande/D-FINE/blob/master/tools/inference/openvino_inf.py
+"""
+
 import cv2
 import numpy as np
 import openvino

--- a/common/rtsploader/dfine_ovinfer.py
+++ b/common/rtsploader/dfine_ovinfer.py
@@ -1,0 +1,79 @@
+import cv2
+import numpy as np
+import openvino
+from openvino.runtime import Core
+
+class OvInfer:
+    def __init__(self, model_path, device_name="CPU"):
+        self.resized_image = None
+        self.ratio = None
+        self.resize_image = None
+        self.ori_image = None
+        self.device = device_name
+        self.model_path = model_path
+        self.core = Core()
+        self.available_device = self.core.available_devices
+        self.compile_model = self.core.compile_model(self.model_path, device_name)
+        self.target_size = [
+            self.compile_model.inputs[0].get_partial_shape()[2].get_length(),
+            self.compile_model.inputs[0].get_partial_shape()[3].get_length(),
+        ]
+        self.query_num = self.compile_model.outputs[0].get_partial_shape()[1].get_length()
+
+    def infer(self, inputs: dict):
+        infer_request = self.compile_model.create_infer_request()
+        for input_name, input_data in inputs.items():
+            input_tensor = openvino.Tensor(input_data)
+            infer_request.set_tensor(input_name, input_tensor)
+        infer_request.infer()
+        outputs = {
+            "labels": infer_request.get_tensor("labels").data,
+            "boxes": infer_request.get_tensor("boxes").data,
+            "scores": infer_request.get_tensor("scores").data,
+        }
+        return outputs
+
+    def process_image(self, ori_image, keep_ratio: bool):
+        self.ori_image = ori_image
+        h, w = ori_image.shape[:2]
+        if keep_ratio:
+            r = min(self.target_size[0] / h, self.target_size[1] / w)
+            self.ratio = r
+            new_w = int(w * r)
+            new_h = int(h * r)
+            temp_image = cv2.resize(ori_image, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
+            resized_image = np.full(
+                (self.target_size[0], self.target_size[1], 3), 114, dtype=temp_image.dtype
+            )
+            resized_image[:new_h, :new_w, :] = temp_image
+            self.resized_image = resized_image
+        else:
+            self.resized_image = cv2.resize(
+                ori_image, self.target_size, interpolation=cv2.INTER_LINEAR
+            )
+        blob_image = cv2.dnn.blobFromImage(self.resized_image, 1.0 / 255.0)
+        orig_size = np.array([self.resized_image.shape[0], self.resized_image.shape[1]], dtype=np.int64).reshape(
+            1, 2
+        )
+
+        inputs = {
+            "images": blob_image,
+            "orig_target_sizes": orig_size,
+        }
+        return inputs
+
+    def draw_and_save_image(self, infer_result, image_path, score_threshold=0.6):
+        draw_image = self.ori_image
+        scores = infer_result["scores"]
+        labels = infer_result["labels"]
+        boxes = infer_result["boxes"]
+        for i in range(self.query_num):
+            if scores[0, i] > score_threshold:
+                cx = boxes[0, i, 0] / self.ratio
+                cy = boxes[0, i, 1] / self.ratio
+                bx = boxes[0, i, 2] / self.ratio
+                by = boxes[0, i, 3] / self.ratio
+                cv2.rectangle(
+                    draw_image, (int(cx), int(cy), int(bx - cx), int(by - cy)), (255, 0, 0), 1
+                )
+        cv2.imwrite(image_path, draw_image)

--- a/common/rtsploader/download_model.sh
+++ b/common/rtsploader/download_model.sh
@@ -6,19 +6,19 @@ set -e
 git clone https://github.com/Peterande/D-FINE.git
 cd D-FINE
 # Get pytorch weights
-wget https://github.com/Peterande/storage/releases/download/dfinev1.0/dfine_l_coco.pth
+wget https://github.com/Peterande/storage/releases/download/dfinev1.0/dfine_s_coco.pth
 # Install conversion requirements
 pip install -r requirements.txt
 pip install onnx onnxsim
-model=l
+model=s
 python tools/deployment/export_onnx.py \
   --check \
-  -c configs/dfine/dfine_hgnetv2_${model}_coco.yml -r dfine_l_coco.pth \
-  -r dfine_l_coco.pth
+  -c configs/dfine/dfine_hgnetv2_${model}_coco.yml -r dfine_s_coco.pth \
+  -r dfine_s_coco.pth
 python <<EOF
 import openvino as ov
-ov_model = ov.convert_model('dfine_l_coco.onnx')
-ov.save_model(ov_model, '../ov_dfine/dfine-l-coco.xml')
+ov_model = ov.convert_model('dfine_s_coco.onnx')
+ov.save_model(ov_model, '../ov_dfine/dfine-s-coco.xml')
 EOF
 
 # Remove extra models/scripts once done

--- a/common/rtsploader/download_model.sh
+++ b/common/rtsploader/download_model.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+# Get conversion packages
+git clone https://github.com/Peterande/D-FINE.git
+cd D-FINE
+# Get pytorch weights
+wget https://github.com/Peterande/storage/releases/download/dfinev1.0/dfine_l_coco.pth
+# Install conversion requirements
+pip install -r requirements.txt
+pip install onnx onnxsim
+model=l
+python tools/deployment/export_onnx.py \
+  --check \
+  -c configs/dfine/dfine_hgnetv2_${model}_coco.yml -r dfine_l_coco.pth \
+  -r dfine_l_coco.pth
+python <<EOF
+import openvino as ov
+ov_model = ov.convert_model('dfine_l_coco.onnx')
+ov.save_model(ov_model, '../ov_dfine/dfine-l-coco.xml')
+EOF
+
+# Remove extra models/scripts once done
+cd ..
+rm -rf D-FINE && true

--- a/common/rtsploader/rtsploader_wrapper.py
+++ b/common/rtsploader/rtsploader_wrapper.py
@@ -51,7 +51,7 @@ class RTSPChunkLoader(BaseLoader):
             # Load OV Model
             from dfine_ovinfer import OvInfer        
             self.dfine_sample_rate = chunk_args.get("dfine_sample_rate", 5)
-            self.dfine_path = chunk_args.get("dfine_path", 'ov_dfine/dfine-l-coco.xml')
+            self.dfine_path = chunk_args.get("dfine_path", 'ov_dfine/dfine-s-coco.xml')
             self.model = OvInfer(self.dfine_path)
             self.detection_threshold = chunk_args.get("detection_threshold", 0.7)
             self.dfine_queue = deque()

--- a/video-summarization/install.sh
+++ b/video-summarization/install.sh
@@ -150,6 +150,8 @@ fi
 
 echo 'y' | conda install pip
 pip install -r requirements.txt
+echo "Downloading and Converting detection model"
+bash ../common/rtsploader/download_model.sh
 
 echo "All installation steps completed successfully."
 


### PR DESCRIPTION
- Switching the ultralytics YOLO model to [D-FINE](https://github.com/Peterande/D-FINE/tree/master) and by default we use the large model trained on the COCO dataset. The download_model.sh script contains the logic for downloading and converting the original pytorch model into an ONNX model, and then finally to an OV version. This must run on CPU, otherwise results are garbage (this is hardcoded in the inference implementation located in the dfine_ovinfer.py).
- A fix allowing for the file consumption to be done before yielding the document that includes the video path is also implemented (a done signal added to consume function).
- Added bounding boxes per detection for ROI extraction which can be used by more advanced VLMs
- Adding DFINE model download and conversion to video_summarization install.sh