### PR TITLE
Update Regex to detect various Anomaly Score pattern outputs from LLM

### DIFF
--- a/langchain-integrations/langchain-summarymerge-score/PKG-INFO
+++ b/langchain-integrations/langchain-summarymerge-score/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.3
 Name: langchain-summarymerge-score
-Version: 0.2.0
+Version: 0.2.1
 Summary: An integration package connecting SummaryMergeScore and LangChain
 License: MIT
 Requires-Python: >=3.9,<4.0

--- a/langchain-integrations/langchain-summarymerge-score/langchain_summarymerge_score/tools.py
+++ b/langchain-integrations/langchain-summarymerge-score/langchain_summarymerge_score/tools.py
@@ -272,7 +272,7 @@ class SummaryMergeScoreTool(BaseTool):  # type: ignore[override]
     def extract_anomaly_score(summary):
         # matching based on multiple scenarios observed; goal is to match floating point or integer after Anomaly Score
         # Anomaly Score sometimes is encapsulated within ** and sometimes LLM omits
-        match = re.search(r"Anomaly Score:?\s*(-?\d+(\.\d+)?)", summary, re.DOTALL)
+        match = re.search(r".*?Anomaly Score.*?:.*?(-?\d+(\.\d+)?)", summary)
         if match:
             return float(match.group(1)) if match.group(1) else 0.0
         return 0.0

--- a/langchain-integrations/langchain-summarymerge-score/langchain_summarymerge_score/tools.py
+++ b/langchain-integrations/langchain-summarymerge-score/langchain_summarymerge_score/tools.py
@@ -272,7 +272,7 @@ class SummaryMergeScoreTool(BaseTool):  # type: ignore[override]
     def extract_anomaly_score(summary):
         # matching based on multiple scenarios observed; goal is to match floating point or integer after Anomaly Score
         # Anomaly Score sometimes is encapsulated within ** and sometimes LLM omits
-        match = re.search(r".*?Anomaly Score.*?:.*?(-?\d+(\.\d+)?)", summary)
+        match = re.search(r".*?Anomaly Score.*?:.*?(-?\d+(\.\d+)?)", summary, re.DOTALL)
         if match:
             return float(match.group(1)) if match.group(1) else 0.0
         return 0.0

--- a/langchain-integrations/langchain-summarymerge-score/pyproject.toml
+++ b/langchain-integrations/langchain-summarymerge-score/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-summarymerge-score"
-version = "0.2.0"
+version = "0.2.1"
 description = "An integration package connecting SummaryMergeScore and LangChain"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
- @ttrigui noticed certain LLM outputs from LLAMA wasn't capturing the Anomaly Score from the regex. Sometimes LLAMA adds **Anomaly Score** even though its not included in the sample LLAMA prompt. 
- Updated regex and updated integration package version number 