### PR TITLE
Change miniCPM model name typo

### DIFF
--- a/vision-rag/vision_rag_image_search.ipynb
+++ b/vision-rag/vision_rag_image_search.ipynb
@@ -641,8 +641,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#export HF_TOKEN=\"<insert HF token here>\"\n",
-    "#!optimum-cli export openvino -m openbmb/MiniCPM-o-2_6 --trust-remote-code --weight-format int4 minicpm_int4"
+    "!HF_TOKEN=\"<insert HF token here>\" optimum-cli export openvino -m openbmb/MiniCPM-V-2_6 --trust-remote-code --weight-format int4 minicpm_int4"
    ]
   },
   {


### PR DESCRIPTION
There is a typo in the model name: MiniCPM-V-2_6 instead of MiniCPM-o-2_6. 