### PR TITLE
Throttle tracking events generation based on video time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out*.txt
 bk/
 vids_*
 vllm/
+*.log

--- a/common/rtsploader/rtsploader_wrapper.py
+++ b/common/rtsploader/rtsploader_wrapper.py
@@ -107,7 +107,10 @@ class RTSPChunkLoader(BaseLoader):
         if len(self.frame_buffer) == self.window_size or last_chunk:
             # Retain start_time, end_time and chunk_id for metadata
             start_time = self.buffer_start_time
-            end_time = start_time + (self.window_size / self.fps)
+            if last_chunk:
+                end_time = start_time + (len(self.frame_buffer) / self.fps)
+            else:
+                end_time = start_time + (self.window_size / self.fps)
             chunk_id = str(uuid.uuid4())
             
             formatted_time = datetime.fromtimestamp(start_time).strftime('%Y-%m-%d_%H-%M-%S')

--- a/video-summarization/src/workers.py
+++ b/video-summarization/src/workers.py
@@ -596,9 +596,8 @@ def show_tracking_data(global_track_ids: dict, interval = 5):
             print("****************************")
         print("-----------------------------------------------------------------------------------------------------")
 
-
 def process_tracking_logs(tracking_logs_q: queue.Queue, milvus_manager: MilvusManager, ov_blip_embedder: OpenVINOBlipEmbeddings, collection_name: str = "tracking_logs"):
-    last_event_time = defaultdict(lambda: 0)
+    last_event_time = defaultdict(lambda: 0.0)
     events = []
     wait_interval = 0.5  
     last_flush = time.time()
@@ -606,20 +605,40 @@ def process_tracking_logs(tracking_logs_q: queue.Queue, milvus_manager: MilvusMa
     while True:
         try:
             event = tracking_logs_q.get(timeout=wait_interval)
+            
             if event is None:
                 break
 
             gid = event["global_track_id"]
-            now = time.time()
-
             event_type = event.get("event_type", "")
+            
             if event_type in ("entry", "exit"):
                 events.append(event)
                 
-            # Process event only if greater than TRACKING_LOGS_GENERATION_TIME_SECS, prevents too many events
-            elif now - last_event_time[gid] >= TRACKING_LOGS_GENERATION_TIME_SECS:
-                last_event_time[gid] = now
-                events.append(event)
+            else:
+                raw_video_time = event.get("last_update", None)
+                video_time = None
+                
+                if isinstance(raw_video_time, (int, float)):
+                    video_time = float(raw_video_time)
+                
+                elif isinstance(raw_video_time, str):
+                    try:
+                        video_time = float(raw_video_time)
+                    except ValueError:
+                        try:
+                            dt = datetime.strptime(raw_video_time, "%Y-%m-%d %H:%M:%S")
+                            video_time = dt.timestamp()
+                        except Exception:
+                            video_time = None
+                
+                if video_time is None:
+                    events.append(event)
+                
+                else:
+                    if video_time - last_event_time[gid] >= TRACKING_LOGS_GENERATION_TIME_SECS:
+                        last_event_time[gid] = video_time
+                        events.append(event)
 
         except queue.Empty:
             pass


### PR DESCRIPTION
Throttle tracking events generation based on their presence in the video aka video timestamps.
Previous logic was using wall clock time.