### PR TITLE
Fix(tracking): signal tracking workers after sampler finishes

### DIFF
--- a/video-summarization/src/main.py
+++ b/video-summarization/src/main.py
@@ -223,10 +223,9 @@ if __name__ == '__main__':
 
         chunk_queue.put(None)
         
+        sample_future.result()
         for video_id, video in videos.items():
             tracking_chunk_queues[video_id].put(None)
-                
-        sample_future.result()
         
         if run_vlm:
             milvus_frames_future.result()
@@ -254,3 +253,4 @@ if __name__ == '__main__':
             process_logs_future.result()
 
         print("[Main]: All tasks completed")
+


### PR DESCRIPTION
Move tracking sentinel to after sample_future.result(), so tracking workers don't exit before sampler distributes chunks, preventing VLM timeouts when tracking events are never set.